### PR TITLE
🐛 822 - encode email param

### DIFF
--- a/python/ego_client.py
+++ b/python/ego_client.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import urllib.parse
 from oauthlib.oauth2 import TokenExpiredError
 
 DEFAULT_PROVIDER = "GOOGLE"
@@ -91,6 +92,7 @@ class EgoClient(object):
 
     def _user_id(self, user):
         filter_field = "email"
+        encoded_user = urllib.parse.quote(user)
         query = f"/users?{filter_field}={user}&providerType={DEFAULT_PROVIDER}"
         result = self._get_json(query)
 

--- a/python/ego_client.py
+++ b/python/ego_client.py
@@ -93,7 +93,7 @@ class EgoClient(object):
     def _user_id(self, user):
         filter_field = "email"
         encoded_user = urllib.parse.quote(user)
-        query = f"/users?{filter_field}={user}&providerType={DEFAULT_PROVIDER}"
+        query = f"/users?{filter_field}={encoded_user}&providerType={DEFAULT_PROVIDER}"
         result = self._get_json(query)
 
         if result['count'] == 0:

--- a/python/report.py
+++ b/python/report.py
@@ -44,7 +44,7 @@ def report_warnings(c):
     fields = ("multiple_entries", "invalid", "invalid_email", "revoke_invalid", "ego_user_not_found")
     counts = zero_defaults(fields, c)
 
-    if not (counts['multiple_entries'] or counts['invalid'] or counts['invalid_email'] or counts['ego_user_notfound']):
+    if not (counts['multiple_entries'] or counts['invalid'] or counts['invalid_email'] or counts['ego_user_not_found']):
         return ""
 
     report = "\n*Warnings*:\n"


### PR DESCRIPTION
Encode `email` param for request to ego `/users` endpoint
fixes typo in `ego_user_not_found` counts key