### PR TITLE
Jenkinsfile update

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,8 @@ spec:
     env:
       - name: DOCKER_HOST
         value: tcp://localhost:2375
+      - name: HOME
+        value: /home/jenkins/agent
   - name: dind-daemon
     image: docker:18.06-dind
     securityContext:


### PR DESCRIPTION
Set explicit HOME env var for docker client container.
Fixes the issue where docker client errors out in the Jenkins pipeline as unable to write into /.docker directory.